### PR TITLE
X-Editable for Yii 1.2.0

### DIFF
--- a/app/config/main.php
+++ b/app/config/main.php
@@ -37,12 +37,11 @@ $mainConfig = array(
         // fixing 'hardcoded aliases' from extension (note: you have to use the full path)
         'application.modules.user.views.asset' => 'vendor.mishamx.yii-user.views.asset',
         'application.modules.user.components' => 'vendor.mishamx.yii-user.components',
-        'ext.editable.assets.js.locales' => 'vendor.vitalets.yii-bootstrap-editable.assets.js.locales',
-        'ext.editable.assets' => 'vendor.vitalets.yii-bootstrap-editable.assets',
         'gii-template-collection' => 'vendor.phundament.gii-template-collection',
         'echosen' => 'vendor.ifdattic.echosen',
         'echosen.EChosen' => 'vendor.ifdattic.echosen.EChosen',
         'ext.EChosen' => 'vendor.ifdattic.echosen',
+        'editable' => 'vendor.vitalets.x-editable-yii',
     ),
     // autoloading model and component classes
     'import' => array(
@@ -62,7 +61,7 @@ $mainConfig = array(
         'vendor.crisu83.yii-rights.components.*', // RWebUser
         'vendor.crisu83.yii-bootstrap.widgets.*', // Bootstrap UI
         'vendor.yiiext.fancybox-widget.*', // Fancybox Widget
-        'vendor.vitalets.yii-bootstrap-editable.*', // p3media
+        'editable.*', // Include X-Editable for Yii classes
     ),
     'modules' => array(
         // uncomment the following to enable the Gii tool
@@ -227,6 +226,16 @@ $mainConfig = array(
             // If you need help with configuring the plugins, please refer to Bootstrap's own documentation:
             // http://twitter.github.com/bootstrap/javascript.html
             ),
+        ),
+        //X-editable config
+        'editable' => array(
+            'class'     => 'editable.EditableConfig',
+            'form'      => 'bootstrap',
+            'mode'      => 'popup',
+            'defaults'  => array(
+               'emptytext' => 'Click to edit',
+               //'ajaxOptions' => array('dataType' => 'json') //useful for json exchange with server
+            )
         ),
         'cache' => array(
             'class' => 'CDummyCache',

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "phundament/p3media":"0.11.*",
         "phundament/p3bootstrap":"0.14.*",
         "phundament/gii-template-collection":"0.8.*",
+        "vitalets/x-editable-yii": "1.2.0",
         "yiiext/fancybox-widget":"0.*",
         "yiiext/lipsum-widget":"0.*",
         "yiiext/migrate-command":"0.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "f35fcb8e20accbe9452b2219d11f24ea",
+    "hash": "d54cf3069e2d3bacbad01a8b5fd9ce76",
     "packages": [
         {
             "name": "anggiaj/eselect2",
@@ -534,6 +534,24 @@
             "time": "2013-03-10 23:22:14"
         },
         {
+            "name": "vitalets/x-editable-yii",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vitalets/x-editable-yii.git",
+                "reference": "064a871c486bd269880fca66642d614df9c6b232"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/vitalets/x-editable-yii/archive/064a871c486bd269880fca66642d614df9c6b232.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "type": "yii-extension",
+            "description": "Yii extension for creating editable elements",
+            "homepage": "https://github.com/vitalets/x-editable-yii"
+        },
+        {
             "name": "vitalets/yii-bootstrap-editable",
             "version": "dev-master",
             "source": {
@@ -834,6 +852,7 @@
         "crisu83/yii-rights": 20,
         "malyshev/yii-debug-toolbar": 20,
         "mishamx/yii-user": 20,
+        "vitalets/x-editable-yii": 20,
         "waalzer/app-demo-data": 20,
         "phundament/lessii": 20,
         "ifdattic/echosen": 20


### PR DESCRIPTION
Rationale: I need working editable widgets and had many issues getting yii-bootstrap-editable to work. It makes sense to add this the successor of yii-bootstrap-editable to phundament/app regardless of the fact that gtc and p3media still haven't been upgraded. Hopefully they will follow suit soon...

Have verified that p3media editable still works after applying this patch on a clean phundament installation.
