### PR TITLE
fix clearing cache after update

### DIFF
--- a/commands/AppController.php
+++ b/commands/AppController.php
@@ -68,7 +68,7 @@ class AppController extends BaseAppController
         }
         $this->composer("install");
         $this->action('migrate');
-        $this->action('cache/flush', 'cache');
+        $this->action('cache/flush', array('cache'));
     }
 
     /**


### PR DESCRIPTION
command:
```
./yii app/update
```

error:
```
...
Running action 'cache/flush'...
PHP Warning 'yii\base\ErrorException' with message 'Invalid argument supplied for foreach()'

in /app/vendor/yiisoft/yii2/console/Controller.php:81

Stack trace:
#0 /app/vendor/yiisoft/yii2/console/Application.php(161): yii\base\Module->runAction()
#1 /app/vendor/dmstr/yii2-app-command/controllers/BaseAppController.php(61): yii\console\Application->runAction()
#2 /app/commands/AppController.php(71): dmstr\console\controllers\BaseAppController->action()
#3 /app/vendor/yiisoft/yii2/base/InlineAction.php(55): app\commands\AppController->actionUpdate()
#4 /app/vendor/yiisoft/yii2/base/InlineAction.php(55): ::call_user_func_array:{/app/vendor/yiisoft/yii2/base/InlineAction.php:55}()
#5 /app/vendor/yiisoft/yii2/base/Controller.php(151): yii\base\InlineAction->runWithParams()
#6 /app/vendor/yiisoft/yii2/console/Controller.php(91): yii\base\Controller->runAction()
#7 /app/vendor/yiisoft/yii2/base/Module.php(455): yii\console\Controller->runAction()
#8 /app/vendor/yiisoft/yii2/console/Application.php(161): yii\base\Module->runAction()
#9 /app/vendor/yiisoft/yii2/console/Application.php(137): yii\console\Application->runAction()
#10 /app/vendor/yiisoft/yii2/base/Application.php(375): yii\console\Application->handleRequest()
#11 /app/yii(26): yii\base\Application->run()
#12 {main}
```