### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ appsrc:
 # Data Services
 # -------------
 mariadb:
-  image: tutum/mariadb:10.1
+  image: tutum/mariadb:10.0
   ports:
     - '3306'
   environment:


### PR DESCRIPTION
Resolves error "tutum/mariadb Tag 10.1 not found" when running: make all