### PR TITLE
FIX: Bootstrap.less relative path in backend site.less

### DIFF
--- a/src/modules/backend/assets/web/site.less
+++ b/src/modules/backend/assets/web/site.less
@@ -1,4 +1,4 @@
-@import "../../../../app/vendor/bower/bootstrap/less/bootstrap.less";
+@import "../../../vendor/bower/bootstrap/less/bootstrap.less";
 
 html,
 body {


### PR DESCRIPTION
Project name 'app' hardcoded site.less causing errors when accessing the backend module index page - if @app does not map to a directory named app.