### PR TITLE
Codeception yii console application init added.

### DIFF
--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -23,3 +23,4 @@ $_SERVER['SERVER_PORT'] =  parse_url(\Codeception\Configuration::config()['confi
 
 Yii::setAlias('@tests', dirname(__DIR__));
 
+new yii\console\Application( require(__DIR__ . '/../../src/config/main.php'));


### PR DESCRIPTION
Not sure if this should work this way or not, but without it codeception throwed me "class not found" exceptions, when I tried to use classes from my components folder ```$helper = new \app\components\XmlHelper();``` something like that in my test function.