### PR TITLE
Fixed permissions issues with GitLab CI runner

### DIFF
--- a/build/scripts/lint.sh
+++ b/build/scripts/lint.sh
@@ -32,10 +32,11 @@ docker-compose run --rm php climb || EXIT_CODE=1
 
 # PHP source
 docker-compose run --rm php vendor/bin/php-cs-fixer fix --format=txt -v --dry-run src || EXIT_CODE=1
-docker run --rm -v "${PWD}:/project" jolicode/phaudit phpcpd src/
+mkdir -p -m 777 "${PWD}/tests/_lint"
+docker run --rm -v "${PWD}:/project" jolicode/phaudit phpmetrics --report-html=tests/_lint/metrics.html src/
+docker run --rm -v "${PWD}:/project" jolicode/phaudit phpcpd src/ > tests/_lint/cpd.txt
 docker run --rm -v "${PWD}:/project" jolicode/phaudit phploc src/ > tests/_lint/loc.txt
 docker run --rm -v "${PWD}:/project" jolicode/phaudit phpmd src html cleancode,codesize,controversial,design,naming,unusedcode > tests/_lint/mess.html
-docker run --rm -v "${PWD}:/project" jolicode/phaudit phpmetrics --report-html=tests/_lint/metrics.html src/
 
 set +v
 

--- a/build/scripts/test.sh
+++ b/build/scripts/test.sh
@@ -11,6 +11,7 @@ set -v
 
 set +e
 
+mkdir -p -m 777 "${PWD}/tests/codeception/_output/debug"
 make TEST run-tests codecept_opts='functional,unit,cli,acceptance -g mandatory --html=_report_mandatory.html' || EXIT_CODE=1
 
 exit ${EXIT_CODE}


### PR DESCRIPTION
Depending on the configuration of the runner (system mode / user mode) the CI
jobs could fail to create, write or delete the reports output directories.

It is fixed by previously creating such directories with 777 permisions.

Fixes #203